### PR TITLE
useToggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.1.0] - 2020-03-06
+
+### Added
+
+* Added `useToggle` hook
+
+## [1.0.0] - 2020-03-06
+
+* Initial release

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ npm install --save @bellawatt/react-hooks
 
 ## Usage
 
+### useDebounceEffect
+
 ```jsx
 import React, { useState } from 'react'
 import axios from 'axios';
@@ -28,6 +30,24 @@ const DebounceEffectExample = () => {
     <div>
       <input value={value} onChange={e => setValue(e.currentTarget.value)} />
     </div>
+  )
+}
+```
+
+### useToggle
+
+```jsx
+import React from 'react'
+import { useToggle } from '@bellawatt/react-hooks'
+import { Modal } from 'reactstrap'
+
+const ToggleExample = () => {
+  const [open, toggle] = useToggle(false)
+
+  return (
+    <Modal isOpen={open} toggle={toggle}>
+      ...
+    </Modal>
   )
 }
 ```

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,9 +1,10 @@
 import React, { useState } from 'react'
-import { useDebounceEffect } from 'react-hooks'
+import { useDebounceEffect, useToggle } from 'react-hooks'
 
 const App = () => {
   const [textValue, setTextValue] = useState('')
   const [exampleValue, setExampleValue] = useState(textValue);
+  const [onOff, toggle] = useToggle(false);
 
   useDebounceEffect(() => {
     setExampleValue(textValue);
@@ -15,6 +16,8 @@ const App = () => {
       <input type="text" value={textValue} onChange={e => setTextValue(e.currentTarget.value)} />
       <p>{textValue}</p>
       <p>{exampleValue}</p>
+      <h2>Toggle Test</h2>
+      <button style={{width: '100px', height: '100px', backgroundColor: onOff ? 'green' : 'red'}} onClick={toggle}>{onOff ? 'On' : 'Off'}</button>
     </div>
   )
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bellawatt/react-hooks",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A collection of hooks we find ourselves turning to in multiple projects",
   "author": "@BrandonShar",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,2 @@
 export { default as useDebounceEffect } from './useDebounceEffect'
+export { default as useToggle } from './useToggle';

--- a/src/useToggle.js
+++ b/src/useToggle.js
@@ -1,0 +1,12 @@
+import { useState } from 'react'
+
+export default function useToggle(initialValue) {
+  const [value, setValue] = useState(initialValue)
+
+  const toggleValue = () => setValue(current => !current)
+
+  return [
+    value,
+    toggleValue
+  ]
+}


### PR DESCRIPTION
I find myself writing a lot of code where the state is toggled as opposed to changed. This requires the same boiler plate every time of `() => setValue(current => ! current)`. What if we could make that simpler? Enter `useToggle`

```jsx
import React from 'react'
import { useToggle } from '@bellawatt/react-hooks'
import { Modal } from 'reactstrap'
const ToggleExample = () => {
  const [open, toggle] = useToggle(false)
  return (
    <Modal isOpen={open} toggle={toggle}>
      ...
    </Modal>
  )
}
```